### PR TITLE
ISSUE: wrong numbering for nested Ordered list.

### DIFF
--- a/ARE/are/src/main/java/com/chinalwb/are/android/inner/Html.java
+++ b/ARE/are/src/main/java/com/chinalwb/are/android/inner/Html.java
@@ -1130,11 +1130,9 @@ class HtmlToSpannedConverter implements ContentHandler {
         OL ol = new OL(level);
         start(text, ol);
         OL_UL_STACK.push(ol);
-        Html.sListNumber = 0;
     }
 
     private void endOL(Editable text) {
-        Html.sListNumber = -1;
         if (OL_UL_STACK.isEmpty()) {
             return;
         }
@@ -1177,8 +1175,9 @@ class HtmlToSpannedConverter implements ContentHandler {
         endBlockElement(text);
         Object peekEle = OL_UL_STACK.peek();
         if (peekEle instanceof OL) {
-            Html.sListNumber = Html.sListNumber + 1;
-            end(text, Numeric.class, new ListNumberSpan(Html.sListNumber));
+            OL ol = (OL) peekEle;
+            end(text, Numeric.class, new ListNumberSpan(ol.getListItemNumber()));
+            ol.incrementListItemNumber();
         } else {
             end(text, Bullet.class, new ListBulletSpan());
         }
@@ -1625,6 +1624,15 @@ class HtmlToSpannedConverter implements ContentHandler {
 
     private static class OL {
         private int level;
+        private int listItemNumber = 1;
+
+        public int getListItemNumber() {
+            return listItemNumber;
+        }
+
+        public void incrementListItemNumber() {
+            listItemNumber++;
+        }
 
         public OL(int level) {
             this.level = level;


### PR DESCRIPTION
- ISSUE: 
    - wrong numbering for nested Ordered list.

- CAUSE:
    - in Html.java file when we are converting html to spanned text.
    - We are only maintaining single variable (sListNumber) for numbering list item.
    - and for every closing "ol" tag we are reseting the sListNumber variable.
    - due to this last element in the parent "ol" is numbered zero.

- Fix:
    - maintained separate variable for numbering list item "li" tag
    - in every "ol" OL object.
    - so now chil "ol" tag is not causing issue to parent "ol" tag.
    - beacause they are completely separate.


Screenshots
|before|after|
|---|---|
|<img width=250 src="https://github.com/chinalwb/Android-Rich-text-Editor/assets/55027190/ce9576d6-2181-4af6-941b-96c70d7ca23a" />|<img width=250 src="https://github.com/chinalwb/Android-Rich-text-Editor/assets/55027190/b10da421-cac6-4f51-9bce-5dc71135f641" />|


